### PR TITLE
fix(startup): cap RLIMIT_NOFILE to 2048 before mn_wifi import (closes #91)

### DIFF
--- a/WifiForge.py
+++ b/WifiForge.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
 
+# Cap RLIMIT_NOFILE (max open file descriptors) before importing mn_wifi.
+# Mininet-wifi's internals iterate over every possible FD up to the soft
+# limit at startup. Distributions with a high default ulimit (Kali 2025+
+# sets RLIMIT_NOFILE to 1,048,576) cause that loop to spend minutes
+# iterating before any lab can start, manifesting to the user as labs
+# stuck at "Loading". 2048 is well above mininet's actual FD needs and
+# brings the iteration cost down to milliseconds.
+#
+# Equivalent to running `ulimit -n 2048` in the shell before launching
+# WifiForge; doing it here so users don't have to remember the workaround.
+#
+# See: https://github.com/blackhillsinfosec/WifiForge/issues/91
+import resource as _resource
+_soft, _hard = _resource.getrlimit(_resource.RLIMIT_NOFILE)
+if _soft > 2048:
+    _resource.setrlimit(_resource.RLIMIT_NOFILE, (2048, _hard))
+
 from blessed import Terminal
 from subprocess import DEVNULL
 import os


### PR DESCRIPTION
Closes #91.

## What the bug is

On a fresh Kali 2025.4 (and any distro with a high default ulimit), WifiForge labs hang at "Loading" indefinitely. The thread on #91 already nailed the root cause — quoting @JsphByd:

> This issue has to do with the mininet code iterating over all possible file descriptors — because kali has a high ulimit it takes a long time to iterate over all of them. I believe the temporary fix is to run: `ulimit -n 2048`

That workaround works, but it's a manual step users have to remember and it has to be done **before** WifiForge is launched. @her3ticAVI replied "if you can find a way to do that we can make the change, Joe and I are short for time lately" — this PR is that.

## What the fix is

Three Python lines at the top of `WifiForge.py`, **before** the `from mn_wifi…` imports, that do the same thing as `ulimit -n 2048` but from inside the process:

```python
import resource as _resource
_soft, _hard = _resource.getrlimit(_resource.RLIMIT_NOFILE)
if _soft > 2048:
    _resource.setrlimit(_resource.RLIMIT_NOFILE, (2048, _hard))
```

- Runs **before** `mn_wifi.mobility` and `mn_wifi.module` are imported, so mininet observes the already-reduced soft limit at import time.
- Only lowers — never raises. The hard limit is left untouched.
- Conditional: if the soft limit is already ≤ 2048 (most non-Kali distros), the call is skipped entirely. Zero behavior change for those users.

A long comment block above the code explains the cause and links back to #91 so future maintainers don't have to chase the thread.

## Verified

```
$ python3 -c "
import resource
print('before:', resource.getrlimit(resource.RLIMIT_NOFILE))
soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
if soft > 2048: resource.setrlimit(resource.RLIMIT_NOFILE, (2048, hard))
print('after: ', resource.getrlimit(resource.RLIMIT_NOFILE))
"
before: (524288, 524288)
after:  (2048, 524288)
```

I don't have a Kali VM handy to run the actual labs against, so I can't confirm "labs no longer hang" end-to-end — that test would need someone on the maintainer team or @rufflabs (who reported the original issue and confirmed the manual `ulimit` fix worked).

## Diff

One file, 17 lines added, zero removed. No functional changes outside the rlimit call.

## Credit

Diagnosis credit to @her3ticAVI and @JsphByd in the #91 thread; reproduction credit to @rufflabs. I just packaged their findings into something automatic.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/